### PR TITLE
properly target service name in ingress

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -23,7 +23,7 @@ spec:
           service:
             port:
               number: 80
-            name: openvas-service
+            name: {{ include "openvas.fullname" . }}-service
         path: /
         pathType: Prefix
   {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -23,7 +23,7 @@ spec:
           service:
             port:
               number: 80
-            name: openvas-service
+            name: {{ include "openvas.fullname" $ }}-service
         path: /
         pathType: Prefix
   {{- end }}


### PR DESCRIPTION
This PR fixes a logic error whereby the service for the ingress object is hardcoded, rather than using the template-generated service name.